### PR TITLE
Switch to deploying the docs using GitHub Actions

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   benchmarks:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,8 +12,8 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,11 +6,19 @@ on:
     tags:
       - 'v*'
 
+# Permissions required for the GitHub Actions Pages deployment.
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment, without cancelling an in-progress run.
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  deploy-docs:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -29,12 +37,18 @@ jobs:
       - name: Generate Documentation
         run: make docs
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Upload Pages Artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/api
-          publish_branch: gh-pages
-          user_name: 'github-actions[bot]'
-          user_email: 'github-actions[bot]@users.noreply.github.com'
-          commit_message: "docs: Deploy documentation from ${{ github.sha }}"
+          path: ./docs/api
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,13 +6,11 @@ on:
     tags:
       - 'v*'
 
-# Permissions required for the GitHub Actions Pages deployment.
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Allow one concurrent deployment, without cancelling an in-progress run.
 concurrency:
   group: pages
   cancel-in-progress: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,12 +11,12 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
-permissions:
-  contents: read
 
 jobs:
   tests:

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .ordered,
-    .version = "0.2.1",
+    .version = "0.2.2",
     .fingerprint = 0xc3121f99b0352e1b, // Changing this has security and trust implications.
     .minimum_zig_version = "0.16.0",
     .paths = .{


### PR DESCRIPTION
* Switched to deploying the docs using GitHub Actions (instead of using the `gh-pages` branch).